### PR TITLE
fix bug: handle empty parameters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ publishing {
 }
 
 group = 'com.samuelbatara.http'
-version = '1.0.1'
+version = '1.0.2'
 sourceCompatibility = '11'
 
 configurations {

--- a/src/main/java/com/demo/proxy/AbstractHttpInvocationHandler.java
+++ b/src/main/java/com/demo/proxy/AbstractHttpInvocationHandler.java
@@ -25,7 +25,11 @@ public abstract class AbstractHttpInvocationHandler {
       this.jsonRpc = JSON_RPC;
       this.id = ID;
       this.method = method;
-      this.params = args;
+      if (args == null) {
+        this.params = new Object[0];
+      } else {
+        this.params = args;
+      }
     }
 
     public void setJsonRpc(String jsonRpc) {


### PR DESCRIPTION
# Descriptions
`params` field will not generated if method has empty arguments. So, params field still need to be initialized with new array.